### PR TITLE
Adds support for NETStandard2.0

### DIFF
--- a/XFormsTouch.NetStandard/XFormsTouch.NetStandard.csproj
+++ b/XFormsTouch.NetStandard/XFormsTouch.NetStandard.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Forms" Version="3.4.0.1008975" />
+    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="..\XFormsTouch.Shared\XFormsTouch.Shared.projitems" Label="Shared" Condition="Exists('..\XFormsTouch.Shared\XFormsTouch.Shared.projitems')" />
+</Project>

--- a/XFormsTouch.NetStandard/XFormsTouch.NetStandard.csproj
+++ b/XFormsTouch.NetStandard/XFormsTouch.NetStandard.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>XFormsTouch</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/XFormsTouch.NuGet/XFormsTouch.NuGet.nuproj
+++ b/XFormsTouch.NuGet/XFormsTouch.NuGet.nuproj
@@ -27,7 +27,7 @@ This is just a handy NuGet package around the Xamarin Sample Code to use the Tou
     <PackageProjectUrl>https://github.com/perpetual-mobile/XFormsTouch</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/perpetual-mobile/XFormsTouch/LICENSE</PackageLicenseUrl>
     <Owners>Perpetual Mobile GmbH</Owners>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup>
 	   <TargetFrameworks>monoandroid81;xamarinios10;net461</TargetFrameworks>
@@ -54,6 +54,10 @@ This is just a handy NuGet package around the Xamarin Sample Code to use the Tou
     <ProjectReference Include="..\XFormsTouch.Net\XFormsTouch.Net.csproj">
       <Project>{62CFD360-F1DD-4482-BF07-C24B8BA2136E}</Project>
       <Name>XFormsTouch.Net</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\XFormsTouch.NetStandard\XFormsTouch.NetStandard.csproj">
+      <Project>{FA07EFE5-46C2-4475-A79E-C3B73BD844C2}</Project>
+      <Name>XFormsTouch.NetStandard</Name>
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>

--- a/XFormsTouch.sln
+++ b/XFormsTouch.sln
@@ -17,6 +17,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XFormsTouch.Net", "XFormsTo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sample.iOS", "Sample.iOS\Sample.iOS.csproj", "{898F65D5-F150-40D2-95F7-D6ADE62E6B33}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XFormsTouch.NetStandard", "XFormsTouch.NetStandard\XFormsTouch.NetStandard.csproj", "{FA07EFE5-46C2-4475-A79E-C3B73BD844C2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -125,5 +127,21 @@ Global
 		{898F65D5-F150-40D2-95F7-D6ADE62E6B33}.Ad-Hoc|iPhone.Build.0 = Ad-Hoc|iPhone
 		{898F65D5-F150-40D2-95F7-D6ADE62E6B33}.AppStore|iPhone.ActiveCfg = AppStore|iPhone
 		{898F65D5-F150-40D2-95F7-D6ADE62E6B33}.AppStore|iPhone.Build.0 = AppStore|iPhone
+		{FA07EFE5-46C2-4475-A79E-C3B73BD844C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FA07EFE5-46C2-4475-A79E-C3B73BD844C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FA07EFE5-46C2-4475-A79E-C3B73BD844C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FA07EFE5-46C2-4475-A79E-C3B73BD844C2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FA07EFE5-46C2-4475-A79E-C3B73BD844C2}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{FA07EFE5-46C2-4475-A79E-C3B73BD844C2}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{FA07EFE5-46C2-4475-A79E-C3B73BD844C2}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{FA07EFE5-46C2-4475-A79E-C3B73BD844C2}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{FA07EFE5-46C2-4475-A79E-C3B73BD844C2}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{FA07EFE5-46C2-4475-A79E-C3B73BD844C2}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{FA07EFE5-46C2-4475-A79E-C3B73BD844C2}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{FA07EFE5-46C2-4475-A79E-C3B73BD844C2}.Release|iPhone.Build.0 = Release|Any CPU
+		{FA07EFE5-46C2-4475-A79E-C3B73BD844C2}.Ad-Hoc|iPhone.ActiveCfg = Debug|Any CPU
+		{FA07EFE5-46C2-4475-A79E-C3B73BD844C2}.Ad-Hoc|iPhone.Build.0 = Debug|Any CPU
+		{FA07EFE5-46C2-4475-A79E-C3B73BD844C2}.AppStore|iPhone.ActiveCfg = Debug|Any CPU
+		{FA07EFE5-46C2-4475-A79E-C3B73BD844C2}.AppStore|iPhone.Build.0 = Debug|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Our more modern Xamarin.Forms projects are using .NETStandard 2 and using this package generates this warning:

```
warning NU1701: Package 'XFormsTouch 1.0.9' was restored using '.NETFramework,Version=v4.6.1, .NETFramework,Version=v4.6.2, .NETFramework,Version=v4.7, .NETFramework,Version=v4.7.1, .NETFramework,Version=v4.7.2, .NETFramework,Version=v4.8' instead of the project target framework '.NETStandard,Version=v2.0'. This package may not be fully compatible with your project.
```

This changes adds a .NETStandard v2 target to the nuget.